### PR TITLE
Remove extra CSP report, add cross-origin headers

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,6 +1,9 @@
 {
 	"globalHeaders": {
-	  "Content-Security-Policy": "default-src 'self'; style-src 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; object-src 'none'; frame-ancestors 'self'; form-action 'none'; upgrade-insecure-requests; base-uri 'self'; report-uri https://kevindreid.report-uri.com/r/d/csp/enforce; report-to 'default'",
+	  "Content-Security-Policy": "default-src 'self'; style-src 'self' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; object-src 'none'; frame-ancestors 'self'; form-action 'none'; upgrade-insecure-requests; base-uri 'self'; report-uri https://kevindreid.report-uri.com/r/d/csp/enforce",
+	  "Cross-Origin-Embedder-Policy": "require-corp; report-to='default'",
+	  "Cross-Origin-Opener-Policy": "same-origin; report-to='default'",
+	  "Cross-Origin-Resource-Policy": "same-origin",
 	  "NEL": "{'report_to':'default','max_age':31536000,'include_subdomains':true}",
 	  "Permissions-Policy": "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()",
 	  "Referrer-Policy": "same-origin",


### PR DESCRIPTION
Removed newer L3 reporting statement from CSP, retained L2 reporting for wider compatibility. Added Cross-Origin-Embedder-Policy, Cross-Origin- Opener-Policy, and Cross-Origin-Resource-Policy headers.